### PR TITLE
feat: Add --help and --version CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   </p>
 </div>
 
-**A lightning-fast, zero-dependency CLI tool to reclaim disk space by finding and removing unnecessary development folders and files.**
+**A CLI tool to reclaim disk space by finding and removing regeneratable development folders.**
 
 It behaves like `npx npkill`, but goes further by detecting multiple categories of heavy folders/files, providing a navigable grouped CLI, and focusing on modern tech stacks like Shopify and React Router—all without a single runtime dependency.
 
@@ -49,6 +49,20 @@ You can specify one or more directories to scan.
 
 ```bash
 npx reclaimspace <foldername>
+```
+
+**To display the version number:**
+
+```bash
+npx reclaimspace --version
+# or
+npx reclaimspace -v
+```
+
+**To display the help message:**
+
+```bash
+npx reclaimspace --help
 ```
 
 **To combine flags and folders:**

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -330,9 +330,9 @@ describe("Program CLI", () => {
       expect(mockExit).toHaveBeenCalledWith(0);
     });
 
-    it("should display version and exit on -V", () => {
+    it("should display version and exit on -v", () => {
       program.version("1.2.3");
-      expect(() => program.parse(["node", "script", "-V"])).toThrow("Process exited with code 0");
+      expect(() => program.parse(["node", "script", "-v"])).toThrow("Process exited with code 0");
       expect(mockLog).toHaveBeenCalledWith("1.2.3");
       expect(mockExit).toHaveBeenCalledWith(0);
     });

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -279,13 +279,62 @@ describe("Program CLI", () => {
     });
 
     it("should parse with various flag separators", () => {
-      program.option("-h, --help", "Help");
-      program.option("-v | --version", "Version");
-      program.parse(["node", "script", "-h", "-v"]);
+      program.option("-x, --extra", "Extra");
+      program.option("-f | --force", "Force");
+      program.parse(["node", "script", "-x", "-f"]);
 
       const opts = program.opts();
-      expect(opts.help).toBe(true);
-      expect(opts.version).toBe(true);
+      expect(opts.extra).toBe(true);
+      expect(opts.force).toBe(true);
+    });
+  });
+
+  describe("help and version flags", () => {
+    let mockExit;
+    let mockLog;
+
+    beforeEach(() => {
+      mockExit = jest.spyOn(process, "exit").mockImplementation((code) => {
+        throw new Error(`Process exited with code ${code}`);
+      });
+      mockLog = jest.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      mockExit.mockRestore();
+      mockLog.mockRestore();
+    });
+
+    it("should display help and exit on --help", () => {
+      program.description("Test description");
+      expect(() => program.parse(["node", "script", "--help"])).toThrow(
+        "Process exited with code 0",
+      );
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("Test description"));
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+
+    it("should display help and exit on -h", () => {
+      program.name("test-app");
+      expect(() => program.parse(["node", "script", "-h"])).toThrow("Process exited with code 0");
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("Usage: test-app"));
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+
+    it("should display version and exit on --version", () => {
+      program.version("1.2.3");
+      expect(() => program.parse(["node", "script", "--version"])).toThrow(
+        "Process exited with code 0",
+      );
+      expect(mockLog).toHaveBeenCalledWith("1.2.3");
+      expect(mockExit).toHaveBeenCalledWith(0);
+    });
+
+    it("should display version and exit on -V", () => {
+      program.version("1.2.3");
+      expect(() => program.parse(["node", "script", "-V"])).toThrow("Process exited with code 0");
+      expect(mockLog).toHaveBeenCalledWith("1.2.3");
+      expect(mockExit).toHaveBeenCalledWith(0);
     });
   });
 

--- a/__tests__/constants.test.js
+++ b/__tests__/constants.test.js
@@ -296,13 +296,7 @@ describe("constants", () => {
 
     it("should contain patterns useful for build detection", () => {
       // Verify patterns are meaningful for detecting build outputs
-      const meaningfulPatterns = [
-        "index.js",
-        "bundle.js",
-        "assets",
-        "webpack.config.js",
-        "*.map",
-      ];
+      const meaningfulPatterns = ["index.js", "bundle.js", "assets", "webpack.config.js", "*.map"];
       meaningfulPatterns.forEach((pattern) => {
         expect(BUILD_ARTIFACT_PATTERNS).toContain(pattern);
       });
@@ -330,7 +324,7 @@ describe("constants", () => {
 
     it("should maintain consistent ordering", () => {
       // Verify that the order in CATEGORIES matches the order in FOLDER_CATEGORIES
-      CATEGORIES.forEach((category, index) => {
+      CATEGORIES.forEach((category, _index) => {
         const folderCategory = FOLDER_CATEGORIES.find((fc) => fc.id === category.id);
         expect(folderCategory).toBeDefined();
       });

--- a/__tests__/prompt.test.js
+++ b/__tests__/prompt.test.js
@@ -1006,7 +1006,12 @@ describe("prompt", () => {
 
       const questions = [
         { type: "confirm", name: "confirm", message: "Confirm?" },
-        { type: "checkbox", name: "check", message: "Check", choices: ["a", "b", "c"] },
+        {
+          type: "checkbox",
+          name: "check",
+          message: "Check",
+          choices: ["a", "b", "c"],
+        },
         { type: "list", name: "list", message: "List", choices: ["x", "y"] },
       ];
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,8 +114,8 @@
       <div class="container">
         <h1 class="display-4">ReclaimSpace Docs</h1>
         <p class="lead">
-          A lightning-fast, zero-dependency CLI tool to reclaim disk space by
-          finding and removing unnecessary development folders and files.
+          A CLI tool to reclaim disk space by finding and removing regeneratable
+          development folders.
         </p>
 
         <!-- Badges -->
@@ -222,6 +222,18 @@
         <pre
           class="position-relative"
         ><button class="copy-btn">Copy</button><code>npx reclaimspace &lt;foldername&gt;</code></pre>
+
+        <h3>Display Version Number</h3>
+        <p>This will display the version number of the tool.</p>
+        <pre
+          class="position-relative"
+        ><button class="copy-btn">Copy</button><code>npx reclaimspace --version</code></pre>
+
+        <h3>Display Help Message</h3>
+        <p>This will display the help message with all available options.</p>
+        <pre
+          class="position-relative"
+        ><button class="copy-btn">Copy</button><code>npx reclaimspace --help</code></pre>
 
         <h3>Combine Flags and Folders</h3>
         <p>You can combine any of the flags with a specific folder.</p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reclaimspace",
   "version": "0.2.0",
-  "description": "A CLI tool to reclaim disk space by finding and removing unnecessary development folders and files.",
+  "description": "A CLI tool to reclaim disk space by finding and removing regeneratable development folders.",
   "main": "src/main.js",
   "packageManager": "pnpm@10.28.2",
   "type": "module",

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -149,7 +149,10 @@ export class Program {
       process.exit(0);
     }
 
-    if (this._version && (rawArgs.includes("--version") || rawArgs.includes("-v"))) {
+    if (
+      this._version &&
+      (rawArgs.includes("--version") || rawArgs.includes("-v") || rawArgs.includes("-V"))
+    ) {
       console.log(this._version);
       process.exit(0);
     }

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -6,10 +6,21 @@ export class Program {
     this.args = [];
     this._options = {};
     this._commands = [];
+    this._name = "";
     this._description = "";
     this._version = "";
     this._argumentDefinitions = [];
     this._optionDefinitions = [];
+  }
+
+  /**
+   * Sets the name of the application.
+   * @param {string} n - Name string.
+   * @returns {Program} Chained instance.
+   */
+  name(n) {
+    this._name = n;
+    return this;
   }
 
   /**
@@ -72,6 +83,58 @@ export class Program {
   }
 
   /**
+   * Generates and returns the help text.
+   * @returns {string} Formatted help text.
+   */
+  helpInformation() {
+    const lines = [];
+
+    if (this._description) {
+      lines.push(this._description);
+      lines.push("");
+    }
+
+    const name = this._name || "program";
+    const usage = `Usage: ${name} [options]${this._argumentDefinitions.length ? ` ${this._argumentDefinitions.map((a) => a.name).join(" ")}` : ""}`;
+    lines.push(usage);
+    lines.push("");
+
+    if (this._argumentDefinitions.length) {
+      lines.push("Arguments:");
+      for (const arg of this._argumentDefinitions) {
+        lines.push(
+          `  ${arg.name.padEnd(20)} ${arg.desc}${arg.defaultValue !== undefined ? ` (default: ${JSON.stringify(arg.defaultValue)})` : ""}`,
+        );
+      }
+      lines.push("");
+    }
+
+    if (this._optionDefinitions.length) {
+      lines.push("Options:");
+      // Add automatic help option to the display
+      const displayOptions = [
+        ...this._optionDefinitions,
+        { flags: "-h, --help", desc: "display help for command" },
+      ];
+      if (this._version) {
+        displayOptions.push({
+          flags: "-v, --version",
+          desc: "output the version number",
+        });
+      }
+
+      for (const opt of displayOptions) {
+        lines.push(
+          `  ${opt.flags.padEnd(20)} ${opt.desc}${opt.defaultValue !== undefined ? ` (default: ${JSON.stringify(opt.defaultValue)})` : ""}`,
+        );
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
    * Parses command line arguments and options.
    * Note: values beginning with "-" must use the --opt=value form.
    * @param {Array<string>} argv - Process arguments list.
@@ -79,6 +142,18 @@ export class Program {
    */
   parse(argv) {
     const rawArgs = argv.slice(2);
+
+    // Handle help and version flags first
+    if (rawArgs.includes("--help") || rawArgs.includes("-h")) {
+      console.log(this.helpInformation());
+      process.exit(0);
+    }
+
+    if (this._version && (rawArgs.includes("--version") || rawArgs.includes("-v"))) {
+      console.log(this._version);
+      process.exit(0);
+    }
+
     const args = [];
     const options = {};
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ function displayLogoAndCredits() {
  */
 async function run(baseDir) {
   const state = { totalReclaimed: 0 };
+  const pkg = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8"));
 
   process.once("SIGINT", () => {
     process.stdout.write(
@@ -40,6 +41,9 @@ Total space reclaimed: ${formatSize(state.totalReclaimed)}
   displayLogoAndCredits();
 
   program
+    .name("reclaimspace")
+    .version(pkg.version)
+    .description(pkg.description)
     .argument("[dirs...]", "Directories to scan")
     .option("-y, --yes", "Auto-delete all found items without confirmation")
     .option("-d, --dry", "Preview only, do not delete anything")

--- a/src/main.js
+++ b/src/main.js
@@ -21,8 +21,13 @@ function displayLogoAndCredits() {
 }
 
 /**
- * Main application runner. Initialized arguments, starts scan, and launches UI.
- * @param {string} baseDir - The root directory of the project.
+ * Run the ReclaimSpace CLI: parse arguments, scan target directories, and launch the UI.
+ *
+ * Reads package metadata for CLI info, resolves and validates search paths, merges ignore/include
+ * patterns, performs a scan with progress reporting, and starts the interactive or non-interactive UI.
+ * Registers a one-time SIGINT handler that prints total reclaimed space and exits.
+ *
+ * @param {string} baseDir - Project root used as the default directory to scan when none are provided.
  */
 async function run(baseDir) {
   const state = { totalReclaimed: 0 };


### PR DESCRIPTION
- Implement name() and helpInformation() methods in Program class
- Add automatic help and version output when --help/-h or --version/-v flags are used
- Update CLI to set name, version, and description from package.json
- Add tests for help and version flag behavior
- Update README.md and docs/index.html with usage documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --help (-h) and --version (-v) flags to display help text and the app version.

* **Documentation**
  * Updated product description to emphasize regeneratable development folders.
  * Added usage examples for help and version flags in README and docs.

* **Tests**
  * Expanded CLI tests to cover help/version output, exit behavior, and parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->