### PR TITLE
docs: remove redundant documentation site badge

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -148,15 +148,6 @@
             />
           </a>
           <a
-            href="https://gaureshpai.github.io/reclaimspace/"
-            class="badge-link"
-          >
-            <img
-              src="https://img.shields.io/badge/documentation-site-green.svg"
-              alt="documentation site"
-            />
-          </a>
-          <a
             href="https://www.npmjs.com/package/reclaimspace"
             class="badge-link"
           >


### PR DESCRIPTION
Removed the "documentation site" shield badge from the docs site index, as it is self-referential in these contexts.

closes #21 