### PR TITLE
feat: add --save-ignore flag for permanent folder exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,18 @@ npx reclaimspace --build-analysis
 
 **To ignore certain folders:**
 
-You can exclude folders from the scan by providing a comma-separated list of patterns.
+You can temporarily exclude folders from the scan by providing a comma-separated list of patterns.
 
 ```bash
 npx reclaimspace --ignore "node_modules,dist"
+```
+
+**To ignore certain folders permanently:**
+
+You can permanently exclude folders from the scan by providing a comma-separated list of patterns. This will update or create a `.reclaimspacerc` file in the current directory.
+
+```bash
+npx reclaimspace --save-ignore "node_modules,dist"
 ```
 
 **To include only specific folders:**

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ npx reclaimspace --ignore "node_modules,dist"
 
 **To ignore certain folders permanently:**
 
-You can permanently exclude folders from the scan by providing a comma-separated list of patterns. This will update or create a `.reclaimspacerc` file in the current directory.
+You can permanently exclude folders from the scan by providing a comma-separated list of patterns. This will update or create a `.reclaimspacerc` file in the current directory using the `--save` or `-s` flag.
 
 ```bash
-npx reclaimspace --save-ignore "node_modules,dist"
+npx reclaimspace --ignore "node_modules,dist" --save
 ```
 
 **To include only specific folders:**

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -29,12 +29,14 @@ describe("Program CLI", () => {
     program.option("-y, --yes", "description");
     program.option("-d, --dry", "description");
     program.option("-u, --ui", "description");
+    program.option("-s, --save", "description");
 
-    program.parse(["node", "script", "-y", "-d", "-u"]);
+    program.parse(["node", "script", "-y", "-d", "-u", "-s"]);
     const opts = program.opts();
     expect(opts.yes).toBe(true);
     expect(opts.dry).toBe(true);
     expect(opts.ui).toBe(true);
+    expect(opts.save).toBe(true);
   });
 
   it("should collect positional arguments", () => {

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { formatSize, formatDate, readIgnoreFile } from "../src/utils.js";
+import { formatSize, formatDate, readIgnoreFile, saveIgnorePatterns } from "../src/utils.js";
 
 jest.mock("node:fs/promises");
 
@@ -51,6 +51,60 @@ describe("utils", () => {
     it("should throw other errors", async () => {
       fs.readFile.mockRejectedValue(new Error("Permission denied"));
       await expect(readIgnoreFile("/mock/dir")).rejects.toThrow("Permission denied");
+    });
+  });
+
+  describe("saveIgnorePatterns", () => {
+    it("should save patterns to a new .reclaimspacerc", async () => {
+      fs.readFile.mockRejectedValue({ code: "ENOENT" });
+      fs.writeFile.mockResolvedValue();
+
+      await saveIgnorePatterns("/mock/dir", ["node_modules", "dist"]);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining(".reclaimspacerc"),
+        "node_modules\ndist\n",
+        "utf-8",
+      );
+    });
+
+    it("should append patterns to an existing .reclaimspacerc", async () => {
+      fs.readFile.mockResolvedValue("existing_pattern\n");
+      fs.writeFile.mockResolvedValue();
+
+      await saveIgnorePatterns("/mock/dir", ["new_pattern"]);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining(".reclaimspacerc"),
+        "existing_pattern\nnew_pattern\n",
+        "utf-8",
+      );
+    });
+
+    it("should not add duplicate patterns", async () => {
+      fs.readFile.mockResolvedValue("existing_pattern\n");
+      fs.writeFile.mockResolvedValue();
+
+      await saveIgnorePatterns("/mock/dir", ["existing_pattern", "new_pattern"]);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining(".reclaimspacerc"),
+        "existing_pattern\nnew_pattern\n",
+        "utf-8",
+      );
+    });
+
+    it("should handle existing file without trailing newline", async () => {
+      fs.readFile.mockResolvedValue("existing_pattern");
+      fs.writeFile.mockResolvedValue();
+
+      await saveIgnorePatterns("/mock/dir", ["new_pattern"]);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining(".reclaimspacerc"),
+        "existing_pattern\nnew_pattern\n",
+        "utf-8",
+      );
     });
   });
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -238,14 +238,16 @@
           class="position-relative"
         ><button class="copy-btn">Copy</button><code>npx reclaimspace --build-analysis</code></pre>
 
-        <h3>Ignore Certain Folders</h3>
+        <h3>Ignore Certain Folders Permanently</h3>
         <p>
-          You can exclude folders from the scan by providing a comma-separated
-          list of patterns.
+          You can permanently exclude folders from the scan by providing a
+          comma-separated list of patterns. This will update or create a
+          <code>.reclaimspacerc</code> file in the current directory using the
+          <code>--save</code> or <code>-s</code> flag.
         </p>
         <pre
           class="position-relative"
-        ><button class="copy-btn">Copy</button><code>npx reclaimspace --ignore "node_modules,dist"</code></pre>
+        ><button class="copy-btn">Copy</button><code>npx reclaimspace --ignore "node_modules,dist" --save</code></pre>
 
         <h3>Include Only Specific Folders</h3>
         <p>

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -71,8 +71,11 @@ export class Program {
     const short = parts.find((p) => p.startsWith("-") && !p.startsWith("--"))?.replace(/^-/, "");
 
     if (long) {
+      // Convert kebab-case to camelCase for the key
+      const camelKey = long.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
       this._optionDefinitions.push({
-        key: long,
+        key: camelKey,
+        rawKey: long,
         short,
         flags,
         desc,
@@ -192,14 +195,15 @@ export class Program {
         }
 
         if (key) {
-          const def = this._optionDefinitions.find((d) => d.key === key);
+          const def = this._optionDefinitions.find((d) => d.key === key || d.rawKey === key);
           if (def) {
+            const targetKey = def.key;
             if (value !== null) {
-              options[key] = value;
+              options[targetKey] = value;
             } else if (rawArgs[i + 1] && !rawArgs[i + 1].startsWith("-")) {
-              options[key] = rawArgs[++i];
+              options[targetKey] = rawArgs[++i];
             } else {
-              options[key] = true;
+              options[targetKey] = true;
             }
             continue;
           }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { program } from "./lib/cli.js";
 import * as ui from "./ui.js";
-import { readIgnoreFile } from "./utils.js";
+import { readIgnoreFile, saveIgnorePatterns } from "./utils.js";
 import { analyzeBuildPatterns } from "./analyzer.js";
 import chalk from "./lib/ansi.js";
 import fs from "node:fs/promises";
@@ -64,10 +64,24 @@ async function run(baseDir) {
       .option("-u, --ui", "Enable interactive UI to select what to delete")
       .option("-i, --ignore <patterns>", "Comma-separated list of patterns to ignore")
       .option("-c, --include <patterns>", "Comma-separated list of patterns to include")
+      .option("-s, --save [patterns]", "Save ignore patterns to .reclaimspacerc")
       .option("-b, --build-analysis", "Enable build analysis logs")
       .parse(process.argv);
 
     const options = program.opts();
+
+    const patternsToSave = [];
+    if (typeof options.save === "string") {
+      patternsToSave.push(...options.save.split(",").filter(Boolean));
+    } else if (options.save && typeof options.ignore === "string") {
+      patternsToSave.push(...options.ignore.split(",").filter(Boolean));
+    }
+
+    if (patternsToSave.length > 0) {
+      await saveIgnorePatterns(baseDir, patternsToSave);
+      console.log(chalk.green(`✔ Saved ignore patterns to ${baseDir}/.reclaimspacerc`));
+    }
+
     let searchPaths = program.args.length ? program.args : [baseDir];
 
     if (!options.ui && !options.dry && !options.yes && program.args.length === 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -65,7 +65,7 @@ Total space reclaimed: ${formatSize(state.totalReclaimed)}
   const options = program.opts();
   let searchPaths = program.args.length ? program.args : [baseDir];
 
-  if (options.saveIgnore) {
+  if (typeof options.saveIgnore === "string") {
     const patternsToSave = options.saveIgnore.split(",").filter(Boolean);
     if (patternsToSave.length > 0) {
       await saveIgnorePatterns(baseDir, patternsToSave);

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { program } from "./lib/cli.js";
 import * as ui from "./ui.js";
-import { readIgnoreFile, formatSize } from "./utils.js";
+import { readIgnoreFile, saveIgnorePatterns, formatSize } from "./utils.js";
 import { analyzeBuildPatterns } from "./analyzer.js";
 import chalk from "./lib/ansi.js";
 import fs from "node:fs/promises";
@@ -54,12 +54,28 @@ Total space reclaimed: ${formatSize(state.totalReclaimed)}
     .option("-d, --dry", "Preview only, do not delete anything")
     .option("-u, --ui", "Enable interactive UI to select what to delete")
     .option("-i, --ignore <patterns>", "Comma-separated list of patterns to ignore")
+    .option(
+      "-s, --save-ignore <patterns>",
+      "Permanently ignore patterns by saving them to .reclaimspacerc",
+    )
     .option("-c, --include <patterns>", "Comma-separated list of patterns to include")
     .option("-b, --build-analysis", "Enable build analysis logs")
     .parse(process.argv);
 
   const options = program.opts();
   let searchPaths = program.args.length ? program.args : [baseDir];
+
+  if (options.saveIgnore) {
+    const patternsToSave = options.saveIgnore.split(",").filter(Boolean);
+    if (patternsToSave.length > 0) {
+      await saveIgnorePatterns(baseDir, patternsToSave);
+      console.log(
+        chalk.green(
+          `Successfully saved ignore patterns to .reclaimspacerc: ${patternsToSave.join(", ")}`,
+        ),
+      );
+    }
+  }
 
   if (!options.ui && !options.dry && !options.yes && program.args.length === 0) {
     options.ui = true;

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,6 +72,44 @@ async function readIgnoreFile(baseDir) {
 }
 
 /**
+ * Saves ignore patterns to .reclaimspacerc.
+ * @param {string} baseDir - The directory to look for .reclaimspacerc in.
+ * @param {Array<string>} patterns - List of glob patterns to ignore.
+ * @returns {Promise<void>}
+ */
+async function saveIgnorePatterns(baseDir, patterns) {
+  const ignoreFilePath = path.join(baseDir, ".reclaimspacerc");
+  let existingContent = "";
+  try {
+    existingContent = await fs.readFile(ignoreFilePath, "utf-8");
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  const existingPatterns = existingContent
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"))
+    .map((line) => line.replace(/^\/+/, ""));
+
+  const patternsToAdd = patterns
+    .map((p) => p.trim().replace(/^\/+/, ""))
+    .filter((p) => p && !existingPatterns.includes(p));
+
+  if (patternsToAdd.length === 0) return;
+
+  let finalContent = existingContent;
+  if (finalContent && !finalContent.endsWith("\n")) {
+    finalContent += "\n";
+  }
+  finalContent += `${patternsToAdd.join("\n")}\n`;
+
+  await fs.writeFile(ignoreFilePath, finalContent, "utf-8");
+}
+
+/**
  * Formats a Date object or timestamp into YYYY-MM-DD.
  * @param {Date|number|string} date - The date to format.
  * @returns {string} Formatted date string.
@@ -84,4 +122,4 @@ function formatDate(date) {
   return `${year}-${month}-${day}`;
 }
 
-export { formatSize, readIgnoreFile, formatDate };
+export { formatSize, readIgnoreFile, saveIgnorePatterns, formatDate };


### PR DESCRIPTION
- Implement --save-ignore (-s) flag to persist ignore patterns to .reclaimspacerc
- Add saveIgnorePatterns utility with deduplication and formatting support
- Update Program CLI to support camelCase option keys from kebab-case flags
- Fix bug where hyphenated flags (like --build-analysis) were not correctly mapped
- Add unit tests for permanent ignore persistence in utils.test.js
- Update README with documentation for temporary and permanent ignore options

Closes #23 