### PR TITLE
feat: save ignore patterns to global config instead of project root (#35)

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -47,7 +47,9 @@ describe("utils", () => {
         Object.defineProperty(process, "platform", { value: "darwin", writable: true });
         process.env.HOME = "/Users/testuser";
         delete process.env.APPDATA;
-        expect(getGlobalConfigDir()).toBe("/Users/testuser/Library/Application Support/reclaimspace");
+        expect(getGlobalConfigDir()).toBe(
+          "/Users/testuser/Library/Application Support/reclaimspace",
+        );
 
         // Test Linux
         Object.defineProperty(process, "platform", { value: "linux", writable: true });
@@ -121,20 +123,20 @@ describe("utils", () => {
       await expect(readIgnoreFile("/mock/dir")).rejects.toThrow("Permission denied");
     });
 
-    it("should local patterns override global (last dedup wins)", async () => {
+    it("should deduplicate patterns when both local and global have the same pattern", async () => {
+      // global has "global_only", local also has it — should appear once
       fs.readFile
-        .mockResolvedValueOnce("common_pattern\n")
-        .mockResolvedValueOnce("common_pattern\n");
+        .mockResolvedValueOnce("shared_pattern\nlocal_only\n")
+        .mockResolvedValueOnce("shared_pattern\nglobal_only\n");
 
       const patterns = await readIgnoreFile("/mock/dir");
 
-      // Should only appear once
-      const count = patterns.filter((p) => p === "common_pattern").length;
-      expect(count).toBe(1);
-      // Verify deduplication results in single pattern and it matches the local (second) value
-      const commonPatterns = patterns.filter((p) => p === "common_pattern");
-      expect(commonPatterns.length).toBe(1);
-      expect(commonPatterns[0]).toBe("common_pattern");
+      // All three distinct patterns present
+      expect(patterns).toContain("shared_pattern");
+      expect(patterns).toContain("local_only");
+      expect(patterns).toContain("global_only");
+      // shared_pattern should appear exactly once
+      expect(patterns.filter((p) => p === "shared_pattern").length).toBe(1);
     });
   });
 

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -33,33 +33,45 @@ describe("utils", () => {
   });
 
   describe("getGlobalConfigDir", () => {
-    it("should return a platform-appropriate config path", () => {
-      const originalPlatform = process.platform;
-      const originalEnv = { ...process.env };
+    it("should return a path ending with reclaimspace", () => {
+      const configDir = getGlobalConfigDir();
+      expect(configDir).toContain("reclaimspace");
+      const basename = configDir.split(/[/\\]/).pop();
+      expect(basename).toBe("reclaimspace");
+    });
 
-      try {
-        // Test Windows
-        Object.defineProperty(process, "platform", { value: "win32", writable: true });
-        process.env.APPDATA = "C:\\Users\\TestUser\\AppData\\Roaming";
-        expect(getGlobalConfigDir()).toBe("C:\\Users\\TestUser\\AppData\\Roaming\\reclaimspace");
+    // Platform-specific tests: only run on the matching OS since
+    // process.platform is non-configurable and cannot be mocked.
+    const testIfWin32 = process.platform === "win32" ? it : it.skip;
+    const testIfDarwin = process.platform === "darwin" ? it : it.skip;
+    const testIfLinux =
+      process.platform !== "win32" && process.platform !== "darwin" ? it : it.skip;
 
-        // Test macOS
-        Object.defineProperty(process, "platform", { value: "darwin", writable: true });
-        process.env.HOME = "/Users/testuser";
-        delete process.env.APPDATA;
-        expect(getGlobalConfigDir()).toBe(
-          "/Users/testuser/Library/Application Support/reclaimspace",
-        );
+    testIfWin32("should use APPDATA on Windows", () => {
+      jest.replaceProperty(process.env, "APPDATA", "C:\\Users\\TestUser\\AppData\\Roaming");
+      expect(getGlobalConfigDir()).toBe("C:\\Users\\TestUser\\AppData\\Roaming\\reclaimspace");
+    });
 
-        // Test Linux
-        Object.defineProperty(process, "platform", { value: "linux", writable: true });
-        process.env.HOME = "/home/testuser";
-        expect(getGlobalConfigDir()).toBe("/home/testuser/.config/reclaimspace");
-      } finally {
-        // Restore original values
-        Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
-        process.env = originalEnv;
-      }
+    testIfDarwin("should use HOME on macOS", () => {
+      jest.replaceProperty(process.env, "HOME", "/Users/testuser");
+      expect(getGlobalConfigDir()).toBe("/Users/testuser/Library/Application Support/reclaimspace");
+    });
+
+    testIfLinux("should use HOME on Linux", () => {
+      jest.replaceProperty(process.env, "HOME", "/home/testuser");
+      expect(getGlobalConfigDir()).toBe("/home/testuser/.config/reclaimspace");
+    });
+
+    testIfLinux("should use XDG_CONFIG_HOME when set", () => {
+      jest.replaceProperty(process.env, "XDG_CONFIG_HOME", "/custom/xdg");
+      expect(getGlobalConfigDir()).toBe("/custom/xdg/reclaimspace");
+    });
+
+    testIfLinux("should fall back to os.homedir() when HOME is empty", () => {
+      jest.replaceProperty(process.env, "HOME", "");
+      const configDir = getGlobalConfigDir();
+      expect(configDir).toContain("reclaimspace");
+      expect(configDir).toContain(".config");
     });
   });
 

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,5 +1,11 @@
 import fs from "node:fs/promises";
-import { formatSize, formatDate, readIgnoreFile, saveIgnorePatterns } from "../src/utils.js";
+import {
+  formatSize,
+  formatDate,
+  readIgnoreFile,
+  saveIgnorePatterns,
+  getGlobalConfigDir,
+} from "../src/utils.js";
 
 jest.mock("node:fs/promises");
 
@@ -26,9 +32,25 @@ describe("utils", () => {
     });
   });
 
+  describe("getGlobalConfigDir", () => {
+    it("should return a platform-appropriate config path", () => {
+      const configDir = getGlobalConfigDir();
+      expect(configDir).toContain("reclaimspace");
+    });
+  });
+
   describe("readIgnoreFile", () => {
+    beforeEach(() => {
+      // By default, mock mkdir to resolve (for global config dir tries)
+      fs.mkdir.mockResolvedValue();
+    });
+
     it("should read patterns from .reclaimspacerc", async () => {
-      fs.readFile.mockResolvedValue("node_modules\n# comment\ndist\n");
+      // First call: local .reclaimspacerc, Second call: global .reclaimspacerc (ENOENT)
+      fs.readFile
+        .mockResolvedValueOnce("node_modules\n# comment\ndist\n")
+        .mockRejectedValueOnce({ code: "ENOENT" });
+
       const patterns = await readIgnoreFile("/mock/dir");
 
       expect(patterns).toContain("node_modules");
@@ -38,10 +60,33 @@ describe("utils", () => {
       expect(patterns).toContain("usr");
     });
 
-    it("should handle missing ignore file", async () => {
-      const error = new Error("File not found");
-      error.code = "ENOENT";
-      fs.readFile.mockRejectedValue(error);
+    it("should read patterns from global config when no local file exists", async () => {
+      // First call: local .reclaimspacerc (ENOENT), Second call: global .reclaimspacerc
+      fs.readFile
+        .mockRejectedValueOnce({ code: "ENOENT" })
+        .mockResolvedValueOnce("global_pattern\n");
+
+      const patterns = await readIgnoreFile("/mock/dir");
+
+      expect(patterns).toContain("global_pattern");
+      expect(patterns).toContain("usr"); // Defaults still present
+    });
+
+    it("should merge local and global patterns", async () => {
+      fs.readFile
+        .mockResolvedValueOnce("local_pattern\n")
+        .mockResolvedValueOnce("global_pattern\n");
+
+      const patterns = await readIgnoreFile("/mock/dir");
+
+      expect(patterns).toContain("local_pattern");
+      expect(patterns).toContain("global_pattern");
+    });
+
+    it("should handle both files missing", async () => {
+      fs.readFile
+        .mockRejectedValueOnce({ code: "ENOENT" })
+        .mockRejectedValueOnce({ code: "ENOENT" });
 
       const patterns = await readIgnoreFile("/mock/dir");
       expect(patterns).toBeDefined();
@@ -49,33 +94,49 @@ describe("utils", () => {
     });
 
     it("should throw other errors", async () => {
-      fs.readFile.mockRejectedValue(new Error("Permission denied"));
+      fs.readFile.mockRejectedValueOnce(new Error("Permission denied"));
+
       await expect(readIgnoreFile("/mock/dir")).rejects.toThrow("Permission denied");
+    });
+
+    it("should local patterns override global (last dedup wins)", async () => {
+      fs.readFile
+        .mockResolvedValueOnce("common_pattern\n")
+        .mockResolvedValueOnce("common_pattern\n");
+
+      const patterns = await readIgnoreFile("/mock/dir");
+
+      // Should only appear once
+      const count = patterns.filter((p) => p === "common_pattern").length;
+      expect(count).toBe(1);
     });
   });
 
   describe("saveIgnorePatterns", () => {
-    it("should save patterns to a new .reclaimspacerc", async () => {
+    beforeEach(() => {
+      fs.mkdir.mockResolvedValue();
+    });
+
+    it("should save patterns to global config directory", async () => {
       fs.readFile.mockRejectedValue({ code: "ENOENT" });
       fs.writeFile.mockResolvedValue();
 
-      await saveIgnorePatterns("/mock/dir", ["node_modules", "dist"]);
+      const configPath = await saveIgnorePatterns(["node_modules", "dist"]);
 
-      expect(fs.writeFile).toHaveBeenCalledWith(
-        expect.stringContaining(".reclaimspacerc"),
-        "node_modules\ndist\n",
-        "utf-8",
-      );
+      expect(configPath).toContain("reclaimspace");
+      expect(configPath).toContain(".reclaimspacerc");
+      expect(fs.mkdir).toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalledWith(configPath, "node_modules\ndist\n", "utf-8");
     });
 
-    it("should append patterns to an existing .reclaimspacerc", async () => {
+    it("should append patterns to an existing global .reclaimspacerc", async () => {
       fs.readFile.mockResolvedValue("existing_pattern\n");
       fs.writeFile.mockResolvedValue();
 
-      await saveIgnorePatterns("/mock/dir", ["new_pattern"]);
+      const configPath = await saveIgnorePatterns(["new_pattern"]);
 
       expect(fs.writeFile).toHaveBeenCalledWith(
-        expect.stringContaining(".reclaimspacerc"),
+        configPath,
         "existing_pattern\nnew_pattern\n",
         "utf-8",
       );
@@ -85,7 +146,7 @@ describe("utils", () => {
       fs.readFile.mockResolvedValue("existing_pattern\n");
       fs.writeFile.mockResolvedValue();
 
-      await saveIgnorePatterns("/mock/dir", ["existing_pattern", "new_pattern"]);
+      await saveIgnorePatterns(["existing_pattern", "new_pattern"]);
 
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining(".reclaimspacerc"),
@@ -98,13 +159,24 @@ describe("utils", () => {
       fs.readFile.mockResolvedValue("existing_pattern");
       fs.writeFile.mockResolvedValue();
 
-      await saveIgnorePatterns("/mock/dir", ["new_pattern"]);
+      await saveIgnorePatterns(["new_pattern"]);
 
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining(".reclaimspacerc"),
         "existing_pattern\nnew_pattern\n",
         "utf-8",
       );
+    });
+
+    it("should create the global config directory if it doesn't exist", async () => {
+      fs.readFile.mockRejectedValue({ code: "ENOENT" });
+      fs.writeFile.mockResolvedValue();
+
+      await saveIgnorePatterns(["test_pattern"]);
+
+      expect(fs.mkdir).toHaveBeenCalledWith(expect.stringContaining("reclaimspace"), {
+        recursive: true,
+      });
     });
   });
 });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -33,45 +33,69 @@ describe("utils", () => {
   });
 
   describe("getGlobalConfigDir", () => {
-    it("should return a path ending with reclaimspace", () => {
+    it("should return a path ending with reclaimspace on current platform", () => {
       const configDir = getGlobalConfigDir();
       expect(configDir).toContain("reclaimspace");
       const basename = configDir.split(/[/\\]/).pop();
       expect(basename).toBe("reclaimspace");
     });
 
-    // Platform-specific tests: only run on the matching OS since
-    // process.platform is non-configurable and cannot be mocked.
-    const testIfWin32 = process.platform === "win32" ? it : it.skip;
-    const testIfDarwin = process.platform === "darwin" ? it : it.skip;
-    const testIfLinux =
-      process.platform !== "win32" && process.platform !== "darwin" ? it : it.skip;
-
-    testIfWin32("should use APPDATA on Windows", () => {
-      jest.replaceProperty(process.env, "APPDATA", "C:\\Users\\TestUser\\AppData\\Roaming");
-      expect(getGlobalConfigDir()).toBe("C:\\Users\\TestUser\\AppData\\Roaming\\reclaimspace");
+    it("should return Windows path using APPDATA", () => {
+      const result = getGlobalConfigDir({
+        platform: "win32",
+        env: { APPDATA: "C:\\Users\\TestUser\\AppData\\Roaming" },
+      });
+      expect(result).toBe("C:\\Users\\TestUser\\AppData\\Roaming\\reclaimspace");
     });
 
-    testIfDarwin("should use HOME on macOS", () => {
-      jest.replaceProperty(process.env, "HOME", "/Users/testuser");
-      expect(getGlobalConfigDir()).toBe("/Users/testuser/Library/Application Support/reclaimspace");
+    it("should return Windows path using USERPROFILE fallback when APPDATA is unset", () => {
+      const result = getGlobalConfigDir({
+        platform: "win32",
+        env: { APPDATA: "", USERPROFILE: "C:\\Users\\TestUser" },
+      });
+      expect(result).toBe("C:\\Users\\TestUser\\AppData\\Roaming\\reclaimspace");
     });
 
-    testIfLinux("should use HOME on Linux", () => {
-      jest.replaceProperty(process.env, "HOME", "/home/testuser");
-      expect(getGlobalConfigDir()).toBe("/home/testuser/.config/reclaimspace");
+    it("should return macOS path using HOME", () => {
+      const result = getGlobalConfigDir({
+        platform: "darwin",
+        env: { HOME: "/Users/testuser" },
+      });
+      expect(result).toBe("/Users/testuser/Library/Application Support/reclaimspace");
     });
 
-    testIfLinux("should use XDG_CONFIG_HOME when set", () => {
-      jest.replaceProperty(process.env, "XDG_CONFIG_HOME", "/custom/xdg");
-      expect(getGlobalConfigDir()).toBe("/custom/xdg/reclaimspace");
+    it("should return Linux path using HOME", () => {
+      const result = getGlobalConfigDir({
+        platform: "linux",
+        env: { HOME: "/home/testuser" },
+      });
+      expect(result).toBe("/home/testuser/.config/reclaimspace");
     });
 
-    testIfLinux("should fall back to os.homedir() when HOME is empty", () => {
-      jest.replaceProperty(process.env, "HOME", "");
-      const configDir = getGlobalConfigDir();
-      expect(configDir).toContain("reclaimspace");
-      expect(configDir).toContain(".config");
+    it("should use XDG_CONFIG_HOME when set (Linux)", () => {
+      const result = getGlobalConfigDir({
+        platform: "linux",
+        env: { XDG_CONFIG_HOME: "/custom/xdg", HOME: "/home/testuser" },
+      });
+      expect(result).toBe("/custom/xdg/reclaimspace");
+    });
+
+    it("should fall back to os.homedir() when HOME is not set", () => {
+      const result = getGlobalConfigDir({
+        platform: "linux",
+        env: {},
+      });
+      expect(result).toContain("reclaimspace");
+      expect(result).toContain(".config");
+    });
+
+    it("should use os.homedir() when HOME is empty string", () => {
+      const result = getGlobalConfigDir({
+        platform: "linux",
+        env: { HOME: "" },
+      });
+      expect(result).toContain("reclaimspace");
+      expect(result).toContain(".config");
     });
   });
 

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -34,8 +34,30 @@ describe("utils", () => {
 
   describe("getGlobalConfigDir", () => {
     it("should return a platform-appropriate config path", () => {
-      const configDir = getGlobalConfigDir();
-      expect(configDir).toContain("reclaimspace");
+      const originalPlatform = process.platform;
+      const originalEnv = { ...process.env };
+
+      try {
+        // Test Windows
+        Object.defineProperty(process, "platform", { value: "win32", writable: true });
+        process.env.APPDATA = "C:\\Users\\TestUser\\AppData\\Roaming";
+        expect(getGlobalConfigDir()).toBe("C:\\Users\\TestUser\\AppData\\Roaming\\reclaimspace");
+
+        // Test macOS
+        Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+        process.env.HOME = "/Users/testuser";
+        delete process.env.APPDATA;
+        expect(getGlobalConfigDir()).toBe("/Users/testuser/Library/Application Support/reclaimspace");
+
+        // Test Linux
+        Object.defineProperty(process, "platform", { value: "linux", writable: true });
+        process.env.HOME = "/home/testuser";
+        expect(getGlobalConfigDir()).toBe("/home/testuser/.config/reclaimspace");
+      } finally {
+        // Restore original values
+        Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+        process.env = originalEnv;
+      }
     });
   });
 
@@ -109,6 +131,10 @@ describe("utils", () => {
       // Should only appear once
       const count = patterns.filter((p) => p === "common_pattern").length;
       expect(count).toBe(1);
+      // Verify deduplication results in single pattern and it matches the local (second) value
+      const commonPatterns = patterns.filter((p) => p === "common_pattern");
+      expect(commonPatterns.length).toBe(1);
+      expect(commonPatterns[0]).toBe("common_pattern");
     });
   });
 

--- a/src/main.js
+++ b/src/main.js
@@ -78,8 +78,8 @@ async function run(baseDir) {
     }
 
     if (patternsToSave.length > 0) {
-      await saveIgnorePatterns(baseDir, patternsToSave);
-      console.log(chalk.green(`✔ Saved ignore patterns to ${baseDir}/.reclaimspacerc`));
+      const configPath = await saveIgnorePatterns(patternsToSave);
+      console.log(chalk.green(`✔ Saved ignore patterns to ${configPath}`));
     }
 
     let searchPaths = program.args.length ? program.args : [baseDir];

--- a/src/main.js
+++ b/src/main.js
@@ -78,8 +78,12 @@ async function run(baseDir) {
     }
 
     if (patternsToSave.length > 0) {
-      const configPath = await saveIgnorePatterns(patternsToSave);
-      console.log(chalk.green(`✔ Saved ignore patterns to ${configPath}`));
+      try {
+        const configPath = await saveIgnorePatterns(patternsToSave);
+        console.log(chalk.green(`✔ Saved ignore patterns to ${configPath}`));
+      } catch (error) {
+        console.error(chalk.red(`Error: Failed to save ignore patterns: ${error.message}`));
+      }
     }
 
     let searchPaths = program.args.length ? program.args : [baseDir];

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,8 @@ function formatSize(bytes) {
  */
 function getGlobalConfigDir() {
   if (process.platform === "win32") {
-    const appData = process.env.APPDATA ||
+    const appData =
+      process.env.APPDATA ||
       path.win32.join(process.env.USERPROFILE || os.homedir(), "AppData", "Roaming");
     return path.win32.join(appData, "reclaimspace");
   }
@@ -81,43 +82,41 @@ async function readIgnoreFile(baseDir = process.cwd()) {
   ]);
 
   // Merge patterns, deduplicating (local overrides take precedence, but we keep global ones too)
-  const patternsSet = new Set([...globalPatterns, ...localPatterns]);
-  const patterns = [...patternsSet];
+  const patternsSet = new Set([
+    ...globalPatterns,
+    ...localPatterns,
+    // Hardcoded default ignores
+    "Program Files",
+    "Program Files (x86)",
+    "Applications",
+    "System",
+    "Library",
+    "usr",
+    "var",
+    "etc",
+    "opt",
+    ".vscode",
+    ".cursor",
+    ".idea",
+    ".sublime-project",
+    ".sublime-workspace",
+    ".atom",
+    ".project",
+    ".classpath",
+    ".settings",
+    "nbproject",
+    ".editorconfig",
+    "src",
+    "source",
+    "app",
+    "lib",
+    "components",
+    "pages",
+    "styles",
+    "assets",
+  ]);
 
-  patterns.push("Program Files");
-  patterns.push("Program Files (x86)");
-
-  patterns.push("Applications");
-  patterns.push("System");
-  patterns.push("Library");
-
-  patterns.push("usr");
-  patterns.push("var");
-  patterns.push("etc");
-  patterns.push("opt");
-
-  patterns.push(".vscode");
-  patterns.push(".cursor");
-  patterns.push(".idea");
-  patterns.push(".sublime-project");
-  patterns.push(".sublime-workspace");
-  patterns.push(".atom");
-  patterns.push(".project");
-  patterns.push(".classpath");
-  patterns.push(".settings");
-  patterns.push("nbproject");
-  patterns.push(".editorconfig");
-
-  patterns.push("src");
-  patterns.push("source");
-  patterns.push("app");
-  patterns.push("lib");
-  patterns.push("components");
-  patterns.push("pages");
-  patterns.push("styles");
-  patterns.push("assets");
-
-  return patterns;
+  return [...patternsSet];
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,12 +61,12 @@ async function readPatternsFromFile(filePath) {
  * @param {string} baseDir - The directory to look for .reclaimspacerc in.
  * @returns {Promise<Array<string>>} List of glob patterns to ignore.
  */
-async function readIgnoreFile(baseDir) {
+async function readIgnoreFile(baseDir = process.cwd()) {
   // Read from both local and global config
-  const localPatterns = await readPatternsFromFile(path.join(baseDir, ".reclaimspacerc"));
-  const globalPatterns = await readPatternsFromFile(
-    path.join(getGlobalConfigDir(), ".reclaimspacerc"),
-  );
+  const [localPatterns, globalPatterns] = await Promise.all([
+    readPatternsFromFile(path.join(baseDir, ".reclaimspacerc")),
+    readPatternsFromFile(path.join(getGlobalConfigDir(), ".reclaimspacerc")),
+  ]);
 
   // Merge patterns, deduplicating (local overrides take precedence, but we keep global ones too)
   const patternsSet = new Set([...globalPatterns, ...localPatterns]);

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,7 +31,7 @@ function formatSize(bytes) {
  */
 function getGlobalConfigDir(overrides = {}) {
   const platform = overrides.platform || process.platform;
-  const env = { ...process.env, ...overrides.env };
+  const env = overrides.env || process.env;
 
   if (platform === "win32") {
     const appData =

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,24 +23,30 @@ function formatSize(bytes) {
  *
  * On Windows, returns `%APPDATA%\reclaimspace` or `~\AppData\Roaming\reclaimspace` if APPDATA is unset.
  * On Linux/macOS, returns `$XDG_CONFIG_HOME/reclaimspace` when XDG_CONFIG_HOME is set, otherwise `~/.config/reclaimspace`.
+ *
+ * @param {Object} [overrides] - Optional overrides (primarily for testing).
+ * @param {string} [overrides.platform] - Platform string (win32, darwin, linux, etc.).
+ * @param {Object} [overrides.env] - Environment variable overrides.
  * @returns {string} Path to the global configuration directory for reclaimspace.
  */
-function getGlobalConfigDir() {
-  if (process.platform === "win32") {
+function getGlobalConfigDir(overrides = {}) {
+  const platform = overrides.platform || process.platform;
+  const env = { ...process.env, ...overrides.env };
+
+  if (platform === "win32") {
     const appData =
-      process.env.APPDATA ||
-      path.win32.join(process.env.USERPROFILE || os.homedir(), "AppData", "Roaming");
+      env.APPDATA || path.win32.join(env.USERPROFILE || os.homedir(), "AppData", "Roaming");
     return path.win32.join(appData, "reclaimspace");
   }
-  if (process.platform === "darwin") {
-    const homeDir = process.env.HOME || os.homedir();
+  if (platform === "darwin") {
+    const homeDir = env.HOME || os.homedir();
     return path.posix.join(homeDir, "Library", "Application Support", "reclaimspace");
   }
-  const xdgConfig = process.env.XDG_CONFIG_HOME;
+  const xdgConfig = env.XDG_CONFIG_HOME;
   if (xdgConfig) {
     return path.posix.join(xdgConfig, "reclaimspace");
   }
-  const homeDir = process.env.HOME || os.homedir();
+  const homeDir = env.HOME || os.homedir();
   return path.posix.join(homeDir, ".config", "reclaimspace");
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,9 +3,12 @@ import path from "node:path";
 import os from "node:os";
 
 /**
- * Formats bytes into a human-readable string (e.g., "1.23 MB").
- * @param {number} bytes - The number of bytes to format.
- * @returns {string} Human-readable size string.
+ * Convert a byte count into a human-readable string using 1024-based units.
+ *
+ * The result is rounded to two decimal places and uses the units: Bytes, KB, MB, GB, TB.
+ * For an input of 0 the function returns "0 Bytes".
+ * @param {number} bytes - Number of bytes to format.
+ * @returns {string} Formatted size string (e.g., "1.23 MB").
  */
 function formatSize(bytes) {
   if (bytes === 0) return "0 Bytes";
@@ -16,10 +19,11 @@ function formatSize(bytes) {
 }
 
 /**
- * Returns the platform-appropriate global config directory for reclaimspace.
- * On Windows: %APPDATA%\reclaimspace
- * On Linux/Mac: $XDG_CONFIG_HOME/reclaimspace or ~/.config/reclaimspace
- * @returns {string} Path to the global config directory.
+ * Compute the platform-specific global configuration directory for reclaimspace.
+ *
+ * On Windows, returns `%APPDATA%\reclaimspace` or `~\AppData\Roaming\reclaimspace` if APPDATA is unset.
+ * On Linux/macOS, returns `$XDG_CONFIG_HOME/reclaimspace` when XDG_CONFIG_HOME is set, otherwise `~/.config/reclaimspace`.
+ * @returns {string} Path to the global configuration directory for reclaimspace.
  */
 function getGlobalConfigDir() {
   if (process.platform === "win32") {
@@ -36,9 +40,13 @@ function getGlobalConfigDir() {
 }
 
 /**
- * Reads patterns from a .reclaimspacerc file at the given path.
+ * Read ignore patterns from a .reclaimspacerc file.
+ *
+ * Lines are trimmed, empty lines and lines starting with `#` are ignored,
+ * and leading `/` characters are removed from each entry. If the file does not
+ * exist, an empty array is returned; other I/O errors are propagated.
  * @param {string} filePath - Path to the .reclaimspacerc file.
- * @returns {Promise<Array<string>>} List of patterns read from the file.
+ * @returns {Array<string>} Array of normalized pattern strings.
  */
 async function readPatternsFromFile(filePath) {
   try {
@@ -109,9 +117,13 @@ async function readIgnoreFile(baseDir = process.cwd()) {
 }
 
 /**
- * Saves ignore patterns to the global .reclaimspacerc config.
- * @param {Array<string>} patterns - List of glob patterns to ignore.
- * @returns {Promise<string>} The path to the saved config file.
+ * Add new ignore patterns to the global .reclaimspacerc file.
+ *
+ * Normalizes each entry by trimming and removing leading slashes, ignores empty or commented lines,
+ * and appends only patterns not already present in the global file. If no new patterns are added,
+ * the function returns the target file path without modifying the file.
+ * @param {Array<string>} patterns - Patterns to add to the global ignore file.
+ * @returns {Promise<string>} The path to the global .reclaimspacerc file (written if new patterns were added).
  */
 async function saveIgnorePatterns(patterns) {
   const globalDir = getGlobalConfigDir();
@@ -151,9 +163,9 @@ async function saveIgnorePatterns(patterns) {
 }
 
 /**
- * Formats a Date object or timestamp into YYYY-MM-DD.
- * @param {Date|number|string} date - The date to format.
- * @returns {string} Formatted date string.
+ * Format a date into YYYY-MM-DD.
+ * @param {Date|number|string} date - A Date object, a millisecond timestamp, or a date-string parseable by Date.
+ * @returns {string} The date formatted as `YYYY-MM-DD`.
  */
 function formatDate(date) {
   const d = new Date(date);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import os from "node:os";
 
 /**
  * Formats bytes into a human-readable string (e.g., "1.23 MB").
@@ -15,16 +16,34 @@ function formatSize(bytes) {
 }
 
 /**
- * Reads ignore patterns from .reclaimspacerc and appends default system ignores.
- * @param {string} baseDir - The directory to look for .reclaimspacerc in.
- * @returns {Promise<Array<string>>} List of glob patterns to ignore.
+ * Returns the platform-appropriate global config directory for reclaimspace.
+ * On Windows: %APPDATA%\reclaimspace
+ * On Linux/Mac: $XDG_CONFIG_HOME/reclaimspace or ~/.config/reclaimspace
+ * @returns {string} Path to the global config directory.
  */
-async function readIgnoreFile(baseDir) {
-  const ignoreFilePath = path.join(baseDir, ".reclaimspacerc");
-  let patterns = [];
+function getGlobalConfigDir() {
+  if (process.platform === "win32") {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"),
+      "reclaimspace",
+    );
+  }
+  const xdgConfig = process.env.XDG_CONFIG_HOME;
+  if (xdgConfig) {
+    return path.join(xdgConfig, "reclaimspace");
+  }
+  return path.join(os.homedir(), ".config", "reclaimspace");
+}
+
+/**
+ * Reads patterns from a .reclaimspacerc file at the given path.
+ * @param {string} filePath - Path to the .reclaimspacerc file.
+ * @returns {Promise<Array<string>>} List of patterns read from the file.
+ */
+async function readPatternsFromFile(filePath) {
   try {
-    const content = await fs.readFile(ignoreFilePath, "utf-8");
-    patterns = content
+    const content = await fs.readFile(filePath, "utf-8");
+    return content
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter((line) => line && !line.startsWith("#"))
@@ -33,7 +52,25 @@ async function readIgnoreFile(baseDir) {
     if (err.code !== "ENOENT") {
       throw err;
     }
+    return [];
   }
+}
+
+/**
+ * Reads ignore patterns from local .reclaimspacerc and global config, then appends default system ignores.
+ * @param {string} baseDir - The directory to look for .reclaimspacerc in.
+ * @returns {Promise<Array<string>>} List of glob patterns to ignore.
+ */
+async function readIgnoreFile(baseDir) {
+  // Read from both local and global config
+  const localPatterns = await readPatternsFromFile(path.join(baseDir, ".reclaimspacerc"));
+  const globalPatterns = await readPatternsFromFile(
+    path.join(getGlobalConfigDir(), ".reclaimspacerc"),
+  );
+
+  // Merge patterns, deduplicating (local overrides take precedence, but we keep global ones too)
+  const patternsSet = new Set([...globalPatterns, ...localPatterns]);
+  const patterns = [...patternsSet];
 
   patterns.push("Program Files");
   patterns.push("Program Files (x86)");
@@ -72,13 +109,16 @@ async function readIgnoreFile(baseDir) {
 }
 
 /**
- * Saves ignore patterns to .reclaimspacerc.
- * @param {string} baseDir - The directory to look for .reclaimspacerc in.
+ * Saves ignore patterns to the global .reclaimspacerc config.
  * @param {Array<string>} patterns - List of glob patterns to ignore.
- * @returns {Promise<void>}
+ * @returns {Promise<string>} The path to the saved config file.
  */
-async function saveIgnorePatterns(baseDir, patterns) {
-  const ignoreFilePath = path.join(baseDir, ".reclaimspacerc");
+async function saveIgnorePatterns(patterns) {
+  const globalDir = getGlobalConfigDir();
+  const ignoreFilePath = path.join(globalDir, ".reclaimspacerc");
+
+  // Ensure the global config directory exists
+  await fs.mkdir(globalDir, { recursive: true });
   let existingContent = "";
   try {
     existingContent = await fs.readFile(ignoreFilePath, "utf-8");
@@ -98,7 +138,7 @@ async function saveIgnorePatterns(baseDir, patterns) {
     .map((p) => p.trim().replace(/^\/+/, ""))
     .filter((p) => p && !existingPatterns.includes(p));
 
-  if (patternsToAdd.length === 0) return;
+  if (patternsToAdd.length === 0) return ignoreFilePath;
 
   let finalContent = existingContent;
   if (finalContent && !finalContent.endsWith("\n")) {
@@ -107,6 +147,7 @@ async function saveIgnorePatterns(baseDir, patterns) {
   finalContent += `${patternsToAdd.join("\n")}\n`;
 
   await fs.writeFile(ignoreFilePath, finalContent, "utf-8");
+  return ignoreFilePath;
 }
 
 /**
@@ -122,4 +163,4 @@ function formatDate(date) {
   return `${year}-${month}-${day}`;
 }
 
-export { formatSize, readIgnoreFile, saveIgnorePatterns, formatDate };
+export { formatSize, readIgnoreFile, saveIgnorePatterns, formatDate, getGlobalConfigDir };

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,16 +27,20 @@ function formatSize(bytes) {
  */
 function getGlobalConfigDir() {
   if (process.platform === "win32") {
-    return path.join(
-      process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"),
-      "reclaimspace",
-    );
+    const appData = process.env.APPDATA ||
+      path.win32.join(process.env.USERPROFILE || os.homedir(), "AppData", "Roaming");
+    return path.win32.join(appData, "reclaimspace");
+  }
+  if (process.platform === "darwin") {
+    const homeDir = process.env.HOME || os.homedir();
+    return path.posix.join(homeDir, "Library", "Application Support", "reclaimspace");
   }
   const xdgConfig = process.env.XDG_CONFIG_HOME;
   if (xdgConfig) {
-    return path.join(xdgConfig, "reclaimspace");
+    return path.posix.join(xdgConfig, "reclaimspace");
   }
-  return path.join(os.homedir(), ".config", "reclaimspace");
+  const homeDir = process.env.HOME || os.homedir();
+  return path.posix.join(homeDir, ".config", "reclaimspace");
 }
 
 /**


### PR DESCRIPTION


Previously, the  flag saved ignore patterns to a  file in the project root directory. This change saves them to a global config directory instead, so patterns set via  apply across all projects.

## Changes

- Added  

- resolves to  (Windows) or  (Linux/Mac)
-  now saves to the global config directory (creates it if needed) instead of the local project root
-  now reads from **both** the local  and the global config, merging patterns with deduplication
- Local  files still work for project-specific overrides
- All 253 existing tests pass

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for platform-specific global ignore patterns configuration directory (Windows `%APPDATA%`, non-Windows uses `XDG_CONFIG_HOME` or `~/.config`).
  * Ignore patterns are now read from and merged with both local and global configurations.

* **Refactor**
  * `saveIgnorePatterns` now persists patterns to the global config directory instead of a local directory; function signature updated accordingly.

* **Tests**
  * Extended test coverage for global configuration handling and pattern merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->