### PR TITLE
feat: add .vitest-attachments and .pnpm-store to default ignore patterns (#36)

### DIFF
--- a/__tests__/constants.test.js
+++ b/__tests__/constants.test.js
@@ -235,7 +235,6 @@ describe("constants", () => {
       expect(buildCategory.names).toContain(".tsbuildinfo");
       expect(buildCategory.names).toContain(".swc");
       expect(buildCategory.names).toContain(".nx");
-      expect(buildCategory.names).toContain(".pnpm-store");
       expect(buildCategory.names).toContain(".wwebjs_cache");
       expect(buildCategory.names).toContain(".wwebjs_auth");
     });

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,7 +44,6 @@ const FOLDER_CATEGORIES = [
       ".tsbuildinfo",
       ".swc",
       ".nx",
-      ".pnpm-store",
       ".wwebjs_cache",
       ".wwebjs_auth",
       "public/build",

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,6 +119,8 @@ async function readIgnoreFile(baseDir = process.cwd()) {
     "components",
     "pages",
     "styles",
+    ".pnpm-store",
+    ".vitest-attachments",
     "assets",
   ]);
 


### PR DESCRIPTION
Add .vitest-attachments and .pnpm-store to default hardcoded ignores so they are excluded from scanning.

.pnpm-store is the pnpm global store - it should never be targeted for deletion.
.vitest-attachments is created by Vitest for test screenshots/artifacts.

Also removed .pnpm-store from FOLDER_CATEGORIES since it will always be ignored now.