### PR TITLE
fix: add .svg extension to GitHub stars badge URL (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://www.npmjs.com/package/reclaimspace"><img src="https://img.shields.io/npm/dt/reclaimspace.svg" alt="npm downloads"></a>
     <a href="https://gaureshpai.github.io/reclaimspace/"><img src="https://img.shields.io/badge/documentation-site-green.svg" alt="documentation site"></a>
     <a href="https://www.npmjs.com/package/reclaimspace"><img src="https://img.shields.io/badge/npm-reclaimspace-cb3837.svg" alt="npm package"></a>
-    <a href="https://github.com/gaureshpai/reclaimspace"><img src="https://img.shields.io/github/stars/gaureshpai/reclaimspace?style=social" alt="github stars"></a>
+    <a href="https://github.com/gaureshpai/reclaimspace"><img src="https://img.shields.io/github/stars/gaureshpai/reclaimspace.svg?style=social" alt="github stars"></a>
   </p>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -161,7 +161,7 @@
             class="badge-link"
           >
             <img
-              src="https://img.shields.io/github/stars/gaureshpai/reclaimspace?style=social"
+              src="https://img.shields.io/github/stars/gaureshpai/reclaimspace.svg?style=social"
               alt="github stars"
             />
           </a>


### PR DESCRIPTION
Fix the GitHub stars badge not rendering in the docs site.

The badge URL was missing the .svg extension, causing shields.io to display 'invalid' instead of the star count. All other badges in the docs already had .svg. Also fixed the same URL in README.md for consistency.

Closes #37