### PR TITLE
fix: disable stdin (keyboard input) during file deletion

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -106,10 +106,13 @@ async function start({ targets, totalSize, duration, options, baseDir, state, bu
     console.log(chalk.yellow("--yes: Deleting all found items..."));
     // Suppress stdin during deletion to prevent accidental keystrokes from corrupting output
     process.stdin.pause();
-    for (const target of targets) {
-      await handleDelete(target, state);
+    try {
+      for (const target of targets) {
+        await handleDelete(target, state);
+      }
+    } finally {
+      process.stdin.resume();
     }
-    process.stdin.resume();
     displaySummary(state);
     return;
   }
@@ -193,10 +196,13 @@ async function interactiveUI(targets, _totalSize, baseDir, state) {
 
       // Suppress stdin during deletion to prevent accidental keystrokes from corrupting output
       process.stdin.pause();
-      for (const target of selectedTargets) {
-        await handleDelete(target, state);
+      try {
+        for (const target of selectedTargets) {
+          await handleDelete(target, state);
+        }
+      } finally {
+        process.stdin.resume();
       }
-      process.stdin.resume();
     }
   } catch (error) {
     if (error.message !== "User interrupted") {

--- a/src/ui.js
+++ b/src/ui.js
@@ -104,9 +104,12 @@ async function start({ targets, totalSize, duration, options, baseDir, state, bu
 
   if (options.yes) {
     console.log(chalk.yellow("--yes: Deleting all found items..."));
+    // Suppress stdin during deletion to prevent accidental keystrokes from corrupting output
+    process.stdin.pause();
     for (const target of targets) {
       await handleDelete(target, state);
     }
+    process.stdin.resume();
     displaySummary(state);
     return;
   }
@@ -188,9 +191,12 @@ async function interactiveUI(targets, _totalSize, baseDir, state) {
       displayTargets(selectedTargets, baseDir);
       console.log("\n");
 
+      // Suppress stdin during deletion to prevent accidental keystrokes from corrupting output
+      process.stdin.pause();
       for (const target of selectedTargets) {
         await handleDelete(target, state);
       }
+      process.stdin.resume();
     }
   } catch (error) {
     if (error.message !== "User interrupted") {


### PR DESCRIPTION
Closes #38

Prevents accidental terminal keystrokes during file deletion by pausing stdin. Pressing Enter while deletes were in progress would echo to the terminal and corrupt the output.

## Changes
- Added process.stdin.pause() before deletion loops and process.stdin.resume() after them in both the --yes auto-deletion path and the interactive UI deletion path