### PR TITLE
feat: add -dc short flag for --deep-clean (#55)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -66,7 +66,7 @@ async function run(baseDir) {
       .option("-c, --include <patterns>", "Comma-separated list of patterns to include")
       .option("-s, --save [patterns]", "Save ignore patterns to .reclaimspacerc")
       .option("-b, --build-analysis", "Enable build analysis logs")
-      .option("--deep-clean", "Also clear package manager caches (npm, pnpm, yarn, pip)")
+      .option("-dc, --deep-clean", "Also clear package manager caches (npm, pnpm, yarn, pip)")
       .parse(process.argv);
 
     const options = program.opts();


### PR DESCRIPTION
## Description
Closes #55

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-dc` short alias for the `--deep-clean` command-line option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->