### PR TITLE
fix: detect Rust target directories and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,13 @@ my-project/dist
 - **Categorized & Grouped:** Results are grouped by type (Node Modules, Build Folders, etc.) for clarity.
 - **Size Information:** See the size of each item and the total reclaimable space.
 - **Concurrent Scanning:** ReclaimSpace uses a concurrent scanner to quickly find and process files.
-- **Build Artifact Detection:** It intelligently detects build folders by looking for common build artifacts.
+- **Build Artifact Detection:** It intelligently detects build folders by looking for common build artifacts, including Rust `target` directories.
 - **Auto-Delete Mode:** Use the `--yes` flag to delete all found items without confirmation.
 - **Dry Run Mode:** Use the `--dry` flag to see what would be deleted without actually deleting anything.
 - **Ignore Patterns:** Exclude specific folders or patterns using a `.reclaimspacerc` file or the `--ignore` flag.
 - **Interactive UI:** Supports 'a' to select all and 'i' to invert selection.
 - **Keyboard Protection:** Terminal input is suppressed during deletion, preventing accidental keystrokes (like Enter) from corrupting the output.
-- **Build Analysis:** Use the `--build-analysis` flag to see inferred project types and common build patterns.
+- **Build Analysis:** Use the `--build-analysis` flag to see inferred project types, including Rust, and common build patterns.
 - **Include Patterns:** Use the `--include` flag to scan only folders matching specific patterns.
 - **Global Config:** Ignore patterns can be saved globally via `--save`, applying across all projects.
 - **Deep Clean Mode:** Use the `--deep-clean` (`-dc`) flag to clear package manager caches (npm, pnpm, yarn, pip) for even more reclaimed space. Shows descriptive reasons when cache size is unchanged.
@@ -175,7 +175,7 @@ my-project/dist
     - `node_modules`
 2.  **Build/Cache Folders**
     - `.next`, `dist`, `build`, `storybook-static`, `.nuxt`, `.output`, `.svelte-kit`, `.angular`, `out`, `.expo`, `.turbo`, `.cache`, `.shopify`, `.react-router`, `.tanstack`, `.vite-ssg-temp`
-    - `.rollup.cache`, `.parcel-cache`, `.vite`, `.astro`, `.solid`, `.remix`, `.docusaurus`, `.eleventy-cache`, `.gatsby-cache`, `public/build`
+    - `.rollup.cache`, `.parcel-cache`, `.vite`, `.astro`, `.solid`, `.remix`, `.docusaurus`, `.eleventy-cache`, `.gatsby-cache`, `public/build`, `target`
     - `.eslintcache`, `.stylelintcache`, `.prettiercache`, `.tsbuildinfo`, `.swc`, `.nx`, `.wwebjs_cache`, `.wwebjs_auth`
 3.  **Testing/Reporting Folders**
     - `coverage`, `.nyc_output`, `.pytest_cache`, `.tox`, `htmlcov`

--- a/__tests__/analyzer.test.js
+++ b/__tests__/analyzer.test.js
@@ -5,12 +5,14 @@ describe("analyzer", () => {
     const targets = [
       { category: "build", buildPatterns: ["angular.json", "package.json"] },
       { category: "build", buildPatterns: ["next.config.js"] },
+      { category: "build", buildPatterns: ["Cargo.toml"] },
       { category: "node_modules", buildPatterns: ["package.json"] }, // Only build category counts
     ];
 
     const result = analyzeBuildPatterns(targets);
     expect(result.inferredProjectTypes.angular).toBe(1);
     expect(result.inferredProjectTypes.nextjs).toBe(1);
+    expect(result.inferredProjectTypes.rust).toBe(1);
     expect(result.inferredProjectTypes.javascript).toBeUndefined(); // Covered by angular
   });
 

--- a/__tests__/constants.test.js
+++ b/__tests__/constants.test.js
@@ -139,6 +139,7 @@ describe("constants", () => {
       expect(buildCategory.names).toContain("build");
       expect(buildCategory.names).toContain(".next");
       expect(buildCategory.names).toContain(".cache");
+      expect(buildCategory.names).toContain("target");
     });
 
     it("should include framework-specific build folders", () => {
@@ -288,6 +289,7 @@ describe("constants", () => {
     it("should include configuration files", () => {
       expect(BUILD_ARTIFACT_PATTERNS).toContain("package.json");
       expect(BUILD_ARTIFACT_PATTERNS).toContain("tsconfig.json");
+      expect(BUILD_ARTIFACT_PATTERNS).toContain("Cargo.toml");
     });
 
     it("should include framework config files", () => {

--- a/__tests__/docs.test.js
+++ b/__tests__/docs.test.js
@@ -96,6 +96,7 @@ describe("Documentation", () => {
           readme.indexOf("**Build Analysis:**") + 150,
         );
         expect(buildAnalysisSection).toContain("--build-analysis");
+        expect(buildAnalysisSection).toContain("Rust");
       });
 
       it("should list 'Include Patterns' as a feature", () => {
@@ -138,6 +139,7 @@ describe("Documentation", () => {
           readme.indexOf("**Testing/Reporting Folders**"),
         );
         expect(buildSection).toContain(".nx");
+        expect(buildSection).toContain("target");
       });
 
       it("Testing/Reporting Folders should have its own line", () => {
@@ -295,6 +297,7 @@ describe("Documentation", () => {
           html.indexOf("Build Analysis:") + 200,
         );
         expect(buildAnalysisSection).toContain("--build-analysis");
+        expect(buildAnalysisSection).toContain("Rust");
       });
 
       it("should list 'Include Patterns' as a feature", () => {
@@ -337,6 +340,7 @@ describe("Documentation", () => {
           html.indexOf("Testing/Reporting Folders"),
         );
         expect(detectedSection).toContain(".nx");
+        expect(detectedSection).toContain("target");
       });
 
       it("should list .wwebjs_cache and .wwebjs_auth in Build/Cache Folders", () => {

--- a/__tests__/scanner.test.js
+++ b/__tests__/scanner.test.js
@@ -199,4 +199,26 @@ describe("scanner", () => {
     expect(targets[0].category).toBe("custom");
     expect(targets[1].category).toBe("custom");
   });
+
+  it("should detect Cargo.toml for Rust target folders", async () => {
+    const rustProjectDir = path.join(FIXTURES_DIR, "rust-project");
+    await createDummyDir(path.join(rustProjectDir, "target"), 1500, ["artifact.bin"]);
+    await fs.writeFile(path.join(rustProjectDir, "Cargo.toml"), '[package]\nname = "demo"\n');
+
+    const mockOnProgress = {
+      start: () => {},
+      increment: () => {},
+      stop: () => {},
+    };
+    const mockSpinner = {
+      stop: () => {},
+      text: "",
+    };
+
+    const { targets } = await scanner.find([rustProjectDir], [], mockOnProgress, mockSpinner);
+    const targetDir = targets.find((t) => t.name === "target");
+
+    expect(targetDir).toBeDefined();
+    expect(targetDir.buildPatterns).toContain("Cargo.toml");
+  });
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -312,7 +312,7 @@
           </li>
           <li>
             <strong>Build Artifact Detection:</strong> Intelligently detects
-            build folders.
+            build folders, including Rust <code>target</code> directories.
           </li>
           <li>
             <strong>Auto-Delete Mode:</strong> Use the <code>--yes</code> flag
@@ -339,7 +339,8 @@
           <li>
             <strong>Build Analysis:</strong> Use the
             <code>--build-analysis</code>
-            flag to see inferred project types and common build patterns.
+            flag to see inferred project types, including Rust, and common
+            build patterns.
           </li>
           <li>
             <strong>Include Patterns:</strong> Use the <code>--include</code>
@@ -475,7 +476,7 @@ my-project/dist</code></pre>
                 <code>.prettiercache</code>, <code>.tsbuildinfo</code>,
                 <code>.swc</code>, <code>.nx</code>, <code>.wwebjs_cache</code>,
                 <code>.wwebjs_auth</code>,
-                <code>public/build</code>
+                <code>public/build</code>, <code>target</code>
               </li>
             </ul>
           </li>

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -25,6 +25,8 @@ function analyzeBuildPatterns(targets) {
         analysis.inferredProjectTypes.vue = (analysis.inferredProjectTypes.vue || 0) + 1;
       } else if (target.buildPatterns.includes("webpack.config.js")) {
         analysis.inferredProjectTypes.webpack = (analysis.inferredProjectTypes.webpack || 0) + 1;
+      } else if (target.buildPatterns.includes("Cargo.toml")) {
+        analysis.inferredProjectTypes.rust = (analysis.inferredProjectTypes.rust || 0) + 1;
       } else if (target.buildPatterns.includes("package.json")) {
         analysis.inferredProjectTypes.javascript =
           (analysis.inferredProjectTypes.javascript || 0) + 1;

--- a/src/constants.js
+++ b/src/constants.js
@@ -47,6 +47,7 @@ const FOLDER_CATEGORIES = [
       ".wwebjs_cache",
       ".wwebjs_auth",
       "public/build",
+      "target",
     ],
   },
   {
@@ -93,6 +94,7 @@ const BUILD_ARTIFACT_PATTERNS = [
   "vue.config.js",
   "next.config.js",
   "tsconfig.json",
+  "Cargo.toml",
 ];
 
 export { CATEGORIES, FOLDER_CATEGORIES, BUILD_ARTIFACT_PATTERNS };

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -26,12 +26,10 @@ async function getBuildPatterns(folderPath) {
     for (const pattern of BUILD_ARTIFACT_PATTERNS) {
       if (pattern === "Cargo.toml" && path.basename(folderPath) === "target") {
         try {
-          const parentEntries = await fs.readdir(path.dirname(folderPath), { withFileTypes: true });
-          if (parentEntries.some((entry) => entry.name === pattern)) {
-            detectedPatterns.push(pattern);
-          }
+          await fs.access(path.join(path.dirname(folderPath), pattern));
+          detectedPatterns.push(pattern);
         } catch (_e) {
-          // ignore inaccessible parent directory; don't abort remaining pattern checks
+          // ignore inaccessible or missing parent Cargo.toml; don't abort remaining pattern checks
         }
         continue;
       }

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -19,9 +19,19 @@ const regexCache = new Map();
  */
 async function getBuildPatterns(folderPath) {
   const detectedPatterns = [];
+
   try {
     const entries = await fs.readdir(folderPath, { withFileTypes: true });
+
     for (const pattern of BUILD_ARTIFACT_PATTERNS) {
+      if (pattern === "Cargo.toml" && path.basename(folderPath) === "target") {
+        const parentEntries = await fs.readdir(path.dirname(folderPath), { withFileTypes: true });
+        if (parentEntries.some((entry) => entry.name === pattern)) {
+          detectedPatterns.push(pattern);
+        }
+        continue;
+      }
+
       if (pattern.includes("*")) {
         let regex = regexCache.get(pattern);
         if (!regex) {

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -25,13 +25,16 @@ async function getBuildPatterns(folderPath) {
 
     for (const pattern of BUILD_ARTIFACT_PATTERNS) {
       if (pattern === "Cargo.toml" && path.basename(folderPath) === "target") {
-        const parentEntries = await fs.readdir(path.dirname(folderPath), { withFileTypes: true });
-        if (parentEntries.some((entry) => entry.name === pattern)) {
-          detectedPatterns.push(pattern);
+        try {
+          const parentEntries = await fs.readdir(path.dirname(folderPath), { withFileTypes: true });
+          if (parentEntries.some((entry) => entry.name === pattern)) {
+            detectedPatterns.push(pattern);
+          }
+        } catch (_e) {
+          // ignore inaccessible parent directory; don't abort remaining pattern checks
         }
         continue;
       }
-
       if (pattern.includes("*")) {
         let regex = regexCache.get(pattern);
         if (!regex) {


### PR DESCRIPTION
- detect Rust `target/` directories as build/cache folders
- infer Rust project type from `Cargo.toml` when scanning `target/`
- update README and docs site to match the new behavior
Closes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing Rust build artifacts, including `target` folders and `Cargo.toml`.
  * Build analysis now reports Rust as an inferred project type.

* **Documentation**
  * Updated the README and generated docs to mention Rust-related build detection and `target` directories.

* **Tests**
  * Expanded automated coverage to verify Rust artifact detection and Rust project-type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->